### PR TITLE
Numeric/Date restriction with invalid ranges

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsMergeOperation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsMergeOperation.java
@@ -9,10 +9,14 @@ public class DateTimeRestrictionsMergeOperation implements RestrictionMergeOpera
 
     @Override
     public Optional<FieldSpec> applyMergeOperation(FieldSpec left, FieldSpec right, FieldSpec merged) {
-        DateTimeRestrictions dateTimeRestrictions = dateTimeRestrictionsMerger.merge(
+        MergeResult<DateTimeRestrictions> mergeResult = dateTimeRestrictionsMerger.merge(
             left.getDateTimeRestrictions(), right.getDateTimeRestrictions());
 
-        if (dateTimeRestrictions == null) {
+        if (!mergeResult.successful) {
+            return Optional.empty();
+        }
+
+        if (mergeResult.restrictions == null) {
             return Optional.of(merged.withDateTimeRestrictions(
                 null,
                 FieldSpecSource.Empty));
@@ -25,7 +29,7 @@ public class DateTimeRestrictionsMergeOperation implements RestrictionMergeOpera
 
         return Optional.of(merged
             .withDateTimeRestrictions(
-                dateTimeRestrictions,
+                mergeResult.restrictions,
                 FieldSpecSource.fromFieldSpecs(left, right))
             .withTypeRestrictions(
                 DataTypeRestrictions.createFromWhiteList(IsOfTypeConstraint.Types.TEMPORAL),

--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsMerger.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsMerger.java
@@ -5,20 +5,24 @@ public class DateTimeRestrictionsMerger {
         MIN, MAX
     }
 
-    public DateTimeRestrictions merge(DateTimeRestrictions left, DateTimeRestrictions right) {
+    public MergeResult<DateTimeRestrictions> merge(DateTimeRestrictions left, DateTimeRestrictions right) {
         if (left == null && right == null)
-            return null;
+            return new MergeResult<>(null);
         if (left == null)
-            return right;
+            return new MergeResult<>(right);
         if (right == null)
-            return left;
+            return new MergeResult<>(left);
 
         final DateTimeRestrictions merged = new DateTimeRestrictions();
 
         merged.min = getMergedLimitStructure(MergeLimit.MIN, left.min, right.min);
         merged.max = getMergedLimitStructure(MergeLimit.MAX, left.max, right.max);
 
-        return merged;
+        if (merged.min != null && merged.max != null && merged.min.getLimit().compareTo(merged.max.getLimit()) >0 ) {
+            return new MergeResult<>();
+        }
+
+        return new MergeResult<>(merged);
     }
 
     private DateTimeRestrictions.DateTimeLimit getMergedLimitStructure(

--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/NumericRestrictionsMerger.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/NumericRestrictionsMerger.java
@@ -24,6 +24,9 @@ public class NumericRestrictionsMerger {
         merged.min = getMergedLimitStructure(MergeLimit.MIN, left.min, right.min);
         merged.max = getMergedLimitStructure(MergeLimit.MAX, left.max, right.max);
 
+        if (merged.min != null && merged.max != null && merged.min.getLimit().compareTo(merged.max.getLimit()) >0 ) {
+            return new MergeResult<>();
+        }
         return new MergeResult<>(merged);
     }
 


### PR DESCRIPTION
- When we currently restrict the data sets to the possible values, we emit invalid ranges for dates and numbers e.g. we allow > 10 and < 1, or > now and < yesterday and set empty value for these fields.

- Proposed change is that we check if we have invalid ranges and if we do, do not emit any data for these cases. This is a change of behaviour now but when we turn the profile validation on, we should not even reach this point anyway (unless it's a very complex contradiction or we do not validate this case yet).

These changes will facilitate the profile validator but are also used in data generation so creating a separate PR for reviewing them.

What are your thoughts?
