### PR TITLE
Fix typo in docs for formatted as

### DIFF
--- a/docs/PresentationalConstraints.md
+++ b/docs/PresentationalConstraints.md
@@ -1,9 +1,8 @@
-# Presentational constraints
 
 ### `formattedAs` _(field, value)_
 
 ```javascript
-{ "field": "price", "is": formattedAs", "value": "%.5s" }
+{ "field": "price", "is": "formattedAs", "value": "%.5s" }
 ```
 
 Used by output serialisers where string output is required. `value` must be:


### PR DESCRIPTION
This resolves issue #132 .

Fixing now as to save time not discussing it at the prioritisation meeting on Thursday. 

add granularTo to the documentation - already included in: docs/EpistemicConstraints.md
add granularTo examples- already included in: docs/EpistemicConstraints.md
add temporal examples- already included in: docs/EpistemicConstraints.md
add temporal date format- already included in: docs/EpistemicConstraints.md
update docs on formattedAs to fix { "field": "price", "is":"formattedAs", "value" : "%.5s" } - fixed in this PR - a " was missing