### PR TITLE
Update combination producer to be more useful

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/ConstraintNode.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/ConstraintNode.java
@@ -1,5 +1,6 @@
 package com.scottlogic.deg.generator.decisiontree;
 
+import com.scottlogic.deg.generator.Field;
 import com.scottlogic.deg.generator.constraints.atomic.AtomicConstraint;
 import com.scottlogic.deg.generator.restrictions.RowSpec;
 
@@ -8,6 +9,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 public interface ConstraintNode extends Node {
     Collection<AtomicConstraint> getAtomicConstraints();
@@ -34,6 +36,10 @@ public interface ConstraintNode extends Node {
         }
 
         return new TreeConstraintNode(atomicConstraints, decisions);
+    }
+
+    default Collection<Field> getConstrainedFields() {
+        return this.getAtomicConstraints().stream().map(AtomicConstraint::getField).collect(Collectors.toSet());
     }
 }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/combination/DecisionTreeCombinationProducer.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/combination/DecisionTreeCombinationProducer.java
@@ -5,16 +5,21 @@ import com.scottlogic.deg.generator.constraints.atomic.AtomicConstraint;
 import com.scottlogic.deg.generator.decisiontree.ConstraintNode;
 import com.scottlogic.deg.generator.decisiontree.DecisionNode;
 import com.scottlogic.deg.generator.decisiontree.DecisionTree;
-import com.scottlogic.deg.generator.generation.FieldSpecValueGenerator;
-import com.scottlogic.deg.generator.generation.GenerationConfig;
-import com.scottlogic.deg.generator.reducer.ConstraintReducer;
-import com.scottlogic.deg.generator.restrictions.FieldSpec;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class DecisionTreeCombinationProducer implements CombinationProducer {
+/**
+ * Produces combinations of values based on a decision tree.
+ *
+ * Will produce combinations for each field in the root node and combinations for each leaf node
+ * that constrains more than one field.
+ */
+public final class DecisionTreeCombinationProducer implements CombinationProducer {
 
     private final DecisionTree tree;
     private final CombinationCreator combinationCreator;
@@ -26,28 +31,37 @@ public class DecisionTreeCombinationProducer implements CombinationProducer {
 
     @Override
     public Stream<Combination> getCombinations() {
-        return this.getConstraintCombinations(tree.getRootNode()).stream();
+        return this.getConstraintCombinations(tree.getRootNode());
     }
 
-    private List<Combination> getConstraintCombinations(ConstraintNode root){
-        return getConstraintCombinations(root, Collections.emptyList());
+    private Stream<Combination> getConstraintCombinations(ConstraintNode root){
+        List<Combination> rootCombinations = root.getConstrainedFields().stream()
+            .flatMap(field -> combinationCreator.makeCombinations(Collections.singletonList(field), root.getAtomicConstraints()).stream())
+            .collect(Collectors.toList());
+
+        return Stream.concat(rootCombinations.stream(), getConstraintCombinationsFromLeaves(root, Collections.emptyList()).stream());
     }
 
-    private List<Combination> getConstraintCombinations(DecisionNode node, Collection<AtomicConstraint> accumulatedConstraints){
+    private List<Combination> getConstraintCombinationsFromLeaves(DecisionNode node, Collection<AtomicConstraint> accumulatedConstraints){
         return node.getOptions().stream()
-            .flatMap(option -> this.getConstraintCombinations(option, accumulatedConstraints).stream())
+            .flatMap(option -> this.getConstraintCombinationsFromLeaves(option, accumulatedConstraints).stream())
             .collect(Collectors.toList());
     }
 
-    private List<Combination> getConstraintCombinations(ConstraintNode node, Collection<AtomicConstraint> accumulatedConstraints){
+    private List<Combination> getConstraintCombinationsFromLeaves(ConstraintNode node, Collection<AtomicConstraint> accumulatedConstraints){
         Collection<AtomicConstraint> currentAccumulation = new HashSet<>(accumulatedConstraints);
         currentAccumulation.addAll(node.getAtomicConstraints());
-        if (node.getDecisions().isEmpty()){
-            Set<Field> fields = node.getAtomicConstraints().stream().map(AtomicConstraint::getField).collect(Collectors.toSet());
-            return combinationCreator.makeCombinations(fields, currentAccumulation);
+        if (node.getDecisions().isEmpty()) {
+            Collection<Field> fields = node.getConstrainedFields();
+            // Create combinations when the constraint node affects more than one field
+            if (fields.size() > 1) {
+                return combinationCreator.makeCombinations(fields, currentAccumulation);
+            } else {
+                return Collections.emptyList();
+            }
         }
         return node.getDecisions().stream()
-            .flatMap(dNode -> this.getConstraintCombinations(dNode, currentAccumulation)
+            .flatMap(dNode -> this.getConstraintCombinationsFromLeaves(dNode, currentAccumulation)
             .stream()).collect(Collectors.toList());
     }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/reductive/CombinationBasedWalker.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/reductive/CombinationBasedWalker.java
@@ -13,6 +13,10 @@ import java.util.Deque;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * Decision tree walker that will use fixed combinations of values as seeds to the Reductive Decision Tree Walker.
+ * More importantly, it only produces a single row for each combination before moving on.
+ */
 public class CombinationBasedWalker implements DecisionTreeWalker {
 
     private final CombinationProducer combinationProducer;
@@ -26,7 +30,7 @@ public class CombinationBasedWalker implements DecisionTreeWalker {
 
     @Override
     public Stream<RowSpec> walk(DecisionTree tree) {
-        Stream<Combination> combinations = combinationProducer.getCombinations().distinct(); // discard combinations that are non unique
+        Stream<Combination> combinations = combinationProducer.getCombinations().distinct(); // discard duplicate combinations
         return FlatMappingSpliterator.flatMap(
             combinations.map(combo -> {
                 Deque<FixedField> initialFixFields = combo.getCombinations().entrySet().stream()


### PR DESCRIPTION
Decision Tree Combination producer will now produce combinations using
the root node, instead of just leaf constraint nodes.