### PR TITLE
Not Null Restriction for Set Restrictions in Fixed Fields

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/reductive/FixedField.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/reductive/FixedField.java
@@ -73,6 +73,9 @@ public class FixedField {
         return FieldSpec.Empty.withSetRestrictions(
             new SetRestrictions(new HashSet<>(Collections.singletonList(currentValue)), null),
             this.valuesFieldSpec.getFieldSpecSource()
+        ).withNullRestrictions(
+            new NullRestrictions(Nullness.MUST_NOT_BE_NULL),
+            this.valuesFieldSpec.getFieldSpecSource()
         );
     }
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/walker/reductive/FixedFieldTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/walker/reductive/FixedFieldTests.java
@@ -1,0 +1,35 @@
+package com.scottlogic.deg.generator.walker.reductive;
+
+import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
+import com.scottlogic.deg.generator.generation.ReductiveDataGeneratorMonitor;
+import com.scottlogic.deg.generator.restrictions.NullRestrictions;
+import com.scottlogic.deg.generator.restrictions.Nullness;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import static org.mockito.Mockito.mock;
+
+class FixedFieldTests {
+    @Test
+    void getFieldSpecForCurrentValue_fieldSpecNullAndCurrentValueNull_returnsFieldSpecWithSetRestrictionsAndNotNullRestrictions() {
+        FixedField fixedField = new FixedField(
+            new Field("Test"),
+            Stream.of(new ArrayList<Object>() {{ add(null); }}),
+            FieldSpec.Empty,
+            mock(ReductiveDataGeneratorMonitor.class)
+        );
+
+        // Stream must be collected to set the current value
+        fixedField.getStream().collect(Collectors.toList());
+        FieldSpec fieldSpec = fixedField.getFieldSpecForCurrentValue();
+
+        Assert.assertNotNull(fieldSpec.getSetRestrictions());
+        Assert.assertNotNull(fieldSpec.getNullRestrictions());
+        Assert.assertEquals(Nullness.MUST_NOT_BE_NULL, fieldSpec.getNullRestrictions().nullness);
+    }
+}


### PR DESCRIPTION
A fix to re-add the not null restriction when returning a set restriction for Fixed Fields