### PR TITLE
Fixed link for profiler example CSV file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The profiler can be run using the following command line arguments:
 
 When the profiler is run it will produce a profile JSON file with the same name as the input file in the specified output location. The profiler will also print diagnostic information to the terminal.
 
-An example input (CSV) that can be used is here: [basic_classifier.csv](.\profiler\src\test\resources\basic_classifier.csv)
+An example input (CSV) that can be used is here: [basic_classifier.csv](./profiler/src/test/resources/basic_classifier.csv)
 
 ### Generator
 


### PR DESCRIPTION
There was a minor typo in the README for setting up the profiler with an example CSV input file. This PR fixes the link to the CSV file.