### PR TITLE
Constraint reducer fix

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpec.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpec.java
@@ -11,16 +11,7 @@ import java.util.stream.Collectors;
  * Details a column's atomic constraints
  */
 public class FieldSpec {
-    public static final FieldSpec Empty = new FieldSpec(null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        FieldSpecSource.Empty);
+    public static final FieldSpec Empty = new EmptyFieldSpec();
 
     private final SetRestrictions setRestrictions;
     private final NumericRestrictions numericRestrictions;
@@ -295,5 +286,26 @@ public class FieldSpec {
             fieldSpec.stringRestrictions,
             fieldSpec.typeRestrictions
         };
+    }
+
+    private static class EmptyFieldSpec extends FieldSpec {
+        public EmptyFieldSpec() {
+            super(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                FieldSpecSource.Empty);
+        }
+
+        @Override
+        public String toString() {
+            return "<empty>";
+        }
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/reducer/ConstraintReducer.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/reducer/ConstraintReducer.java
@@ -66,13 +66,13 @@ public class ConstraintReducer {
 
     public Optional<FieldSpec> reduceConstraintsToFieldSpec(Iterable<AtomicConstraint> rootConstraints,
                                                             Iterable<AtomicConstraint> decisionConstraints) {
-        if (rootConstraints == null || !rootConstraints.iterator().hasNext()) {
-            return Optional.of(FieldSpec.Empty);
-        }
-
         final FieldSpec decisionConstaintsFieldSpec = fieldSpecFactory.toMustContainRestrictionFieldSpec(
             StreamSupport.stream(decisionConstraints.spliterator(), false).collect(Collectors.toSet())
         );
+
+        if (rootConstraints == null || !rootConstraints.iterator().hasNext()) {
+            return Optional.of(decisionConstaintsFieldSpec);
+        }
 
         final Stream<FieldSpec> rootAndDecisionsConstraintsStream = Stream.concat(
             Stream.of(decisionConstaintsFieldSpec),

--- a/generator/src/main/java/com/scottlogic/deg/generator/reducer/ConstraintReducer.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/reducer/ConstraintReducer.java
@@ -66,9 +66,10 @@ public class ConstraintReducer {
 
     public Optional<FieldSpec> reduceConstraintsToFieldSpec(Iterable<AtomicConstraint> rootConstraints,
                                                             Iterable<AtomicConstraint> decisionConstraints) {
-        final FieldSpec decisionConstaintsFieldSpec = fieldSpecFactory.toMustContainRestrictionFieldSpec(
-            StreamSupport.stream(decisionConstraints.spliterator(), false).collect(Collectors.toSet())
-        );
+        final FieldSpec decisionConstaintsFieldSpec = decisionConstraints.iterator().hasNext()
+            ? fieldSpecFactory.toMustContainRestrictionFieldSpec(
+                StreamSupport.stream(decisionConstraints.spliterator(), false).collect(Collectors.toSet()))
+            : FieldSpec.Empty;
 
         if (rootConstraints == null || !rootConstraints.iterator().hasNext()) {
             return Optional.of(decisionConstaintsFieldSpec);

--- a/generator/src/test/java/com/scottlogic/deg/generator/reducer/ConstraintReducerTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/reducer/ConstraintReducerTest.java
@@ -1001,6 +1001,26 @@ class ConstraintReducerTest {
                 Matchers.greaterThan(0L));
     }
 
+    @Test
+    void shouldReduceToConstraintsFoundInDecisions() {
+        final Field field = new Field("test0");
+
+        List<AtomicConstraint> decisionConstraints = Arrays.asList(
+            new IsEqualToConstantConstraint(field, "a", rules()));
+
+        Optional<FieldSpec> testOutput = constraintReducer.reduceConstraintsToFieldSpec(
+            Collections.emptySet(),
+            decisionConstraints
+        );
+
+        FieldSpec outputSpec = testOutput.get();
+
+        Assert.assertThat("Fieldspec is not empty", outputSpec,
+            not(equalTo(FieldSpec.Empty)));
+        Assert.assertThat("Fieldspec has must contain restriction",
+            outputSpec.getMustContainRestriction(), not(nullValue()));
+    }
+
     private static Set<RuleInformation> rules(){
         RuleDTO rule = new RuleDTO();
         rule.rule = "rules";

--- a/generator/src/test/java/com/scottlogic/deg/generator/reducer/ConstraintReducerTest.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/reducer/ConstraintReducerTest.java
@@ -1019,6 +1019,11 @@ class ConstraintReducerTest {
             not(equalTo(FieldSpec.Empty)));
         Assert.assertThat("Fieldspec has must contain restriction",
             outputSpec.getMustContainRestriction(), not(nullValue()));
+        Set<FieldSpec> requiredObjects = outputSpec.getMustContainRestriction().getRequiredObjects();
+        Assert.assertThat("Must contain has one required object",
+            requiredObjects.size(), is(1));
+        Assert.assertThat("Required object has a set restriction",
+            requiredObjects.iterator().next().getSetRestrictions(), not(nullValue()));
     }
 
     private static Set<RuleInformation> rules(){


### PR DESCRIPTION
Introduced EmptyFieldSpec to aid debugging
Changed ConstraintReducer to accept an empty set of root-level atomic constraints (in which case return a field spec for the decision-level constraints, if any)