### PR TITLE
Add PR Template to the project

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Related Issue
+<!--- This project only accepts pull requests related to open issues -->
+<!--- If suggesting a new feature or change, please discuss it in an issue first -->
+<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
+<!--- Please link to the issue here: -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Screenshots (if appropriate):
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have read the **CONTRIBUTING** document.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,11 @@
 #### Description
-<!--- A brief description of your changes including a link to the associated Issue Number. -->
+<!--- A brief description of your changes. --->
 
 #### Changes
 <!--- Summary of changes to guide the reviewer(s). --->
 
 #### Additional notes
 <!--- OPTIONAL: notes about new documentation added, testing to consider, impact on other areas of code or work if relevant. --->
+
+#### Issue
+<!--- Include a link to the associated Issue Number including the keyword Resolves e.g. Resolves #123 --->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,8 @@
-<!--- Provide a general summary of your changes in the Title above -->
+#### Description
+<!--- A brief description of your changes including a link to the associated Issue Number. -->
 
-## Description
-<!--- Describe your changes in detail -->
+#### Changes
+<!--- Summary of changes to guide the reviewer(s). --->
 
-## Motivation and Context
-<!--- Why is this change required? What problem does it solve? Which issue does it resolve? -->
-
-## Tests
-<!-- Has this change been tested and how? Are automated tests required and made? Have you considered how this change might affect other areas of the code? -->
-
-## Documentation
-<!-- Are documentation updates required and made? -->
+#### Additional notes
+<!--- OPTIONAL: notes about new documentation added, testing to consider, impact on other areas of code or work if relevant. --->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,34 +3,11 @@
 ## Description
 <!--- Describe your changes in detail -->
 
-## Related Issue
-<!--- This project only accepts pull requests related to open issues -->
-<!--- If suggesting a new feature or change, please discuss it in an issue first -->
-<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
-<!--- Please link to the issue here: -->
-
 ## Motivation and Context
-<!--- Why is this change required? What problem does it solve? -->
+<!--- Why is this change required? What problem does it solve? Which issue does it resolve? -->
 
-## How Has This Been Tested?
-<!--- Please describe in detail how you tested your changes. -->
-<!--- Include details of your testing environment, and the tests you ran to -->
-<!--- see how your change affects other areas of the code, etc. -->
+## Tests
+<!-- Has this change been tested and how? Are automated tests required and made? Have you considered how this change might affect other areas of the code? -->
 
-## Screenshots (if appropriate):
-
-## Types of changes
-<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to change)
-
-## Checklist:
-<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [ ] My code follows the code style of this project.
-- [ ] My change requires a change to the documentation.
-- [ ] I have updated the documentation accordingly.
-- [ ] I have read the **CONTRIBUTING** document.
-- [ ] I have added tests to cover my changes.
-- [ ] All new and existing tests passed.
+## Documentation
+<!-- Are documentation updates required and made? -->


### PR DESCRIPTION
#### Description
Add a PR template to the project so that every time we create a new PR we are prompted with some ideas on what would be useful to include in the description.

#### Motivation and Context
This is to help reviewers understand and review your code better and also to use as a reference as to why were changes made and how were they tested.

#### Tests
This change has not been tested. The expected behaviour is that once it is merged to master, any new PRs will have this template in their description:
https://help.github.com/articles/about-issue-and-pull-request-templates/

#### Documentation
N/A.
