### PR TITLE
424 - Add AllOf constraint validation

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/inputs/MainConstraintReader.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/inputs/MainConstraintReader.java
@@ -46,6 +46,9 @@ public class MainConstraintReader implements ConstraintReader {
         }
 
         if (dto.allOf != null) {
+            if (dto.allOf.isEmpty()) {
+                throw new InvalidProfileException("AllOf must contain at least one constraint.");
+            }
             return new AndConstraint(
                 ProfileReader.mapDtos(
                     dto.allOf,

--- a/generator/src/test/java/com/scottlogic/deg/generator/inputs/ProfileReaderTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/inputs/ProfileReaderTests.java
@@ -520,4 +520,33 @@ public class ProfileReaderTests {
 
         expectInvalidProfileException();
     }
+
+    @Test
+    public void shouldRejectAllOfWithEmptySet() {
+        givenJson("{" +
+            "    \"schemaVersion\": \"v3\"," +
+            "    \"fields\": [ { \"name\": \"foo\" } ]," +
+            "    \"rules\": [{" +
+            "        \"allOf\": []" +
+            "    }]" +
+            "}");
+
+        this.expectInvalidProfileException();
+    }
+
+    @Test
+    public void shouldRejectAllOfWithEmptySetWithExplicitConstraint() {
+        givenJson("{" +
+            "    \"schemaVersion\": \"v3\"," +
+            "    \"fields\": [ { \"name\": \"foo\" } ]," +
+            "    \"rules\": [{" +
+            "        \"rule\": \"foo rule\"," +
+            "        \"constraints\": [{" +
+            "           \"allOf\": []" +
+            "        }]" +
+            "    }]" +
+            "}");
+
+        this.expectInvalidProfileException();
+    }
 }


### PR DESCRIPTION
#### Description
When parsing the profile we want the generator to throw validation errors early as opposed to getting stuck half way through a profile. The "allOf" constraint should always contain constraints and hence this change will throw up a validation error if the JSON value is empty.

#### Changes
* Added empty check to ensure that AllOF constraint has at least one constraint inside.
* Added to ProfilerReaderTests.java to test new validation.

#### Issue
Resolves #424 