### PR TITLE
Ignore inconsistent test

### DIFF
--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/MatchingRegex.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/MatchingRegex.feature
@@ -580,7 +580,7 @@ Scenario: Running a 'matchingRegex' request as part of a contradicting allOf con
       | "a"  | null  |
       | "c"  | null  |
 
-
+@ignore ''' test is inconsistent, it passes *most* of the time when debugging, and fails *most* of the time when running normally
   Scenario: Running a 'matchingRegex' and 'inSet' and 'numeric' request nulls are generated last
     Given there is a field bar
     And the combination strategy is exhaustive


### PR DESCRIPTION
This change ignores a test in the cucumber framework which produces inconsistent results